### PR TITLE
Add location selection on map in the parcel identifier

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -240,6 +240,7 @@ tr:hover {
 .button.success {
   background-color: #3dc798;
   color: white;
+  font-weight: bold;
 }
 
 .button.success.shadow {

--- a/src/assets/translations.csv
+++ b/src/assets/translations.csv
@@ -41,6 +41,8 @@ tools_parcel_identifier_information,Informations,Information
 tools_parcel_identifier_cadastre,Cadastre,Cadastre
 tools_parcel_identifier_cap,Informations PAC,CAP information
 
+map_selector_label,Déplacez le curseur ou saisissez des coordonnées géographiques.,Move the cursor or enter geographic coordinates.
+
 datasets,Jeux de données,Datasets
 filter,Filtrer,Filter
 send,Envoyer,send

--- a/src/templates/components/Form.tsx
+++ b/src/templates/components/Form.tsx
@@ -113,7 +113,7 @@ export function Form(props: Props) {
           <button
             type="submit"
             class="success shadow button"
-            style={{ height: "54px", width: "100%", fontWeight: "bold" }}
+            style={{ height: "54px", width: "100%" }}
           >
             {props.submitLabel}
           </button>

--- a/src/templates/components/Grid.tsx
+++ b/src/templates/components/Grid.tsx
@@ -17,6 +17,7 @@ export function Grid(props: Props) {
         padding: "10px",
         flexWrap: "wrap",
         flexDirection: "row",
+        flexFlow: "wrap",
       }}
     >
       {props.children}
@@ -47,6 +48,7 @@ export function Cell(props: CellProps) {
         width: percent,
         flexBasis: percent,
         flexWrap: "wrap",
+        alignItems: "baseline",
       }}
     >
       {children}

--- a/src/templates/components/MapSelector.tsx
+++ b/src/templates/components/MapSelector.tsx
@@ -1,0 +1,165 @@
+import { Html } from "@elysiajs/html"
+import { type Geometry } from "../../types/Geometry"
+import type { Coordinates } from "../../types/Coordinates"
+import type { Translator } from "../../Translator"
+import { Cell, Grid } from "./Grid"
+
+interface Props {
+  center: Coordinates
+  t: Translator
+  marker?: Coordinates
+  shape?: Geometry
+}
+
+const DEFAULT_ZOOM = 16
+
+export function MapSelector(props: Props) {
+  const uniqid = Date.now()
+
+  const marker = props.marker
+    ? `marker = L.marker([${props.marker.latitude}, ${props.marker.longitude}]).addTo(map${uniqid});`
+    : ""
+
+  const shape = props.shape
+    ? `L.geoJSON(${JSON.stringify(
+        props.shape,
+      )}, {onEachFeature: onEachFeature}).addTo(map${uniqid})`
+    : ""
+
+  return (
+    <>
+      <form>
+        {" "}
+        <Grid>
+          <Cell width={8}>
+            {" "}
+            <div id={"map-" + uniqid} style={{ width: "100%", height: "300px" }}></div>
+          </Cell>
+
+          <Cell width={4}>
+            <div
+              style={{
+                height: "100%",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+              }}
+            >
+              <Grid>
+                {" "}
+                <Cell width={12}>
+                  <i>{props.t("map_selector_label")}</i>
+                </Cell>
+                <Cell width={12}>
+                  <div class="field">
+                    <label for={"latitude"}>{props.t("common_fields_latitude")}</label>
+                    <br />
+                    <input
+                      type="number"
+                      step="any"
+                      autocomplete="off"
+                      id={"latitude"}
+                      name={"latitude"}
+                      required={true}
+                      placeholder={props.t("common_fields_latitude")}
+                      value={
+                        props.marker?.latitude.toString() ||
+                        props.center.latitude.toString()
+                      }
+                    ></input>
+                    {"°"}
+                  </div>
+                </Cell>
+                <Cell width={12}>
+                  <div class="field">
+                    <label for={"latitude"}>{props.t("common_fields_longitude")}</label>
+                    <br />
+                    <input
+                      type="number"
+                      step="any"
+                      autocomplete="off"
+                      id={"longitude"}
+                      name={"longitude"}
+                      required={true}
+                      placeholder={props.t("common_fields_longitude")}
+                      value={
+                        props.marker?.longitude.toString() ||
+                        props.center.longitude.toString()
+                      }
+                    ></input>
+                    {"°"}
+                  </div>
+                </Cell>
+                <Cell width={12}>
+                  <input type="submit" class="success shadow button"></input>
+                </Cell>
+              </Grid>
+            </div>
+          </Cell>
+        </Grid>
+      </form>
+
+      <link
+        rel="stylesheet"
+        href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+        crossorigin=""
+      />
+      <script
+        src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+        crossorigin=""
+      ></script>
+
+      {`
+      <script> 
+        function onEachFeature(feature, layer) {
+            if (feature.properties && feature.properties.html) {
+                layer.bindPopup(feature.properties.html);
+            }
+        }
+
+        let map${uniqid} = L.map('map-${uniqid}')
+            .setView([${props.center.latitude}, ${
+        props.center.longitude
+      }], ${DEFAULT_ZOOM});
+        
+        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          })
+          .addTo(map${uniqid});
+
+
+        let marker
+
+
+        ${
+          !props.marker
+            ? `map${uniqid}.locate({setView: true, maxZoom: 16});`
+            : `map${uniqid}.setView([${props.marker.latitude}, ${props.marker.longitude}])`
+        }
+
+        function onMove(e) {
+            const center = map${uniqid}.getCenter();
+            if (marker) {
+                marker.setLatLng(center)
+            } else {
+               marker = L.marker(center);
+                marker.addTo(map${uniqid});
+            }
+          
+            document.querySelector('#latitude').value = center.lat
+            document.querySelector('#longitude').value = center.lng      
+        }
+
+        map${uniqid}.on('move', onMove);        
+        map${uniqid}.on('zoom', onMove);        
+
+        ${marker}
+        ${shape}
+      </script>
+      `}
+    </>
+  )
+}

--- a/src/templates/pages/ParcelIdentifier.tsx
+++ b/src/templates/pages/ParcelIdentifier.tsx
@@ -1,13 +1,14 @@
 import { Html } from "@elysiajs/html"
 import type { Translator } from "../../Translator"
 import { Layout } from "../layouts/Layout"
-import { Field, Form, type FormDefinition } from "../components/Form"
+import { type FormDefinition } from "../components/Form"
 import { match, type Result } from "shulk"
 import { Error } from "../components/Error"
 import type { Hypermedia, HypermediaType } from "../../Hypermedia"
 import { Map } from "../components/Map"
 import type { Coordinates } from "../../types/Coordinates"
 import type { MultiPolygon } from "../../types/Geometry"
+import { MapSelector } from "../components/MapSelector"
 
 export interface ParcelIdentifierOkPage {
   title: string
@@ -27,6 +28,9 @@ interface Props {
   page: Result<Error, ParcelIdentifierOkPage>
 }
 
+const DEFAULT_LATITUDE = 48.831561189145276
+const DEFAULT_LONGITUDE = 2.2884060615145954
+
 export function ParcelIdentifier(props: Props) {
   const { page, t } = props
 
@@ -34,25 +38,18 @@ export function ParcelIdentifier(props: Props) {
     Err: ({ val: error }) => <Error error={error} />,
     Ok: ({ val }) => (
       <Layout title={val.title} breadcrumbs={val.breadcrumbs} t={t}>
-        <Form definition={val.form} method="GET" submitLabel={t("send")} />
+        <MapSelector
+          center={{ latitude: DEFAULT_LATITUDE, longitude: DEFAULT_LONGITUDE }}
+          t={t}
+          marker={val.geolocation?.coordinates}
+          shape={val.geolocation?.shape}
+        />
 
         {renderSection(t("tools_parcel_identifier_information"), val.information)}
 
         {renderSection(t("tools_parcel_identifier_cadastre"), val.cadastre)}
 
         {renderSection(t("tools_parcel_identifier_cap"), val.cap)}
-
-        {val.geolocation && (
-          <>
-            <h2>{t("common_location")}</h2>
-
-            <Map
-              center={val.geolocation.coordinates}
-              markers={[val.geolocation.coordinates]}
-              shapes={[val.geolocation.shape]}
-            />
-          </>
-        )}
       </Layout>
     ),
   })


### PR DESCRIPTION
To enhance the parcel identifier UX, we want to allow users to select a point near their location on a map to get the information of the corresponding parcel. There is now a new map selector component that allow us to do that.

![Capture d’écran 2025-03-06 à 12 04 40](https://github.com/user-attachments/assets/ae6a91e4-ad35-4c04-877a-e5c875d91f0d)

![Capture d’écran 2025-03-06 à 12 04 15](https://github.com/user-attachments/assets/83ad6798-26c7-457c-84d7-cb032f8a61f7)
